### PR TITLE
Improvement in invalid content condition

### DIFF
--- a/translator.js
+++ b/translator.js
@@ -70,7 +70,7 @@ module.exports = (from ,to ,text ,callback) => {
 				translations:[]
 			};
 			
-			if (content[7] != null ){
+			if (content[7] != null && content[7].length !== 0){
 				translated.isCorrect = false;
 				translated.text = content[7][1];
 			}else{


### PR DESCRIPTION
In line 73: Google returns an empty array instead of NULL